### PR TITLE
Fixed project name bug on user dashboard

### DIFF
--- a/imports/api/projects/server/publications.js
+++ b/imports/api/projects/server/publications.js
@@ -41,3 +41,27 @@ Meteor.publish('projectGet', function retrieveProject(projectId) {
     managers: this.userId }, { employees: this.userId }] }] });
   return project;
 });
+
+Meteor.publish('projectNames', function projectNamesPublish(projectIdList) {
+  // Given a list of userIds, return the name of those users
+  check(projectIdList, Array);
+
+  const currentUser = Meteor.users.findOne(this.userId);
+
+  if (currentUser == null || currentUser.profile == null) {
+    return null;
+  }
+
+  const ids = [];
+  for (let i = 0; i < projectIdList.length; i += 1) {
+    if (!projectIdList[i].projectId) {
+      break;
+    }
+    ids.push(projectIdList[i].projectId);
+  }
+
+  const find = { $or: [{ _id: { $in: ids } }, { _id: { $in: projectIdList } }] };
+  const projection = { name: 1 };
+  const names = Projects.find(find, projection);
+  return names;
+});

--- a/imports/ui/components/userDashboardContainer.jsx
+++ b/imports/ui/components/userDashboardContainer.jsx
@@ -15,11 +15,13 @@ const UserDashboardContainer = createContainer(() => {
   const projectSub = Meteor.subscribe('projects');
   const requestSub = Meteor.subscribe('requests');
   let userNameSub = null;
+  let projectNameSub = null;
 
   // Subscription ready
   const projectReady = projectSub.ready();
   const requestReady = requestSub.ready();
   let userReady = null;
+  let projectNameReady = null;
 
   // Projects and Requests
   let employeeProjects = [];
@@ -53,6 +55,14 @@ const UserDashboardContainer = createContainer(() => {
     userReady = userNameSub.ready();
     users = (userReady && Meteor.users.find().fetch()) || [];
   }
+  const requestProjectIds = requestReady &&
+    Requests.find({}, { fields: { projectId: 1 } }).fetch();
+  let projectNames = [];
+  if (requestProjectIds) {
+    projectNameSub = Meteor.subscribe('projectNames', requestProjectIds);
+    projectNameReady = projectNameSub.ready();
+    projectNames = (projectNameReady && Projects.find().fetch()) || [];
+  }
 
   // Helper props
   const isEmployee = employeeProjects && employeeProjects.length > 0;
@@ -76,6 +86,7 @@ const UserDashboardContainer = createContainer(() => {
     myRequests,
     managerRequests,
     users,
+    projectNames,
     isManager,
     isEmployee,
   };

--- a/imports/ui/pages/userDashboard.jsx
+++ b/imports/ui/pages/userDashboard.jsx
@@ -38,6 +38,7 @@ const UserDashboard = React.createClass({
     myRequests: React.PropTypes.array,
     managerRequests: React.PropTypes.array,
     users: React.PropTypes.array,
+    projectNames: React.PropTypes.array,
     isManager: React.PropTypes.bool,
     isEmployee: React.PropTypes.bool,
   },
@@ -53,6 +54,7 @@ const UserDashboard = React.createClass({
       myRequests: [],
       managerRequests: [],
       users: [],
+      projectNames: [],
       isManager: false,
       isEmployee: false,
       viewToggle: localStorage.getItem('viewToggle') === 'true' || false,
@@ -72,6 +74,7 @@ const UserDashboard = React.createClass({
       myRequests: this.props.myRequests,
       managerRequests: this.props.managerRequests,
       users: this.props.users,
+      projectNames: this.props.projectNames,
       isManager: this.props.isManager,
       isEmployee: this.props.isEmployee,
       viewToggle: this.state.viewToggle && this.props.isManager,
@@ -89,6 +92,7 @@ const UserDashboard = React.createClass({
     const myRequestsChange = this.state.myRequests !== nextProps.myRequests;
     const managerRequestsChange = this.state.managerRequests !== nextProps.managerRequests;
     const usersChange = this.state.users !== nextProps.users;
+    const projectNamesChange = this.state.projectNames !== nextProps.projectNames;
     const isManagerChange = this.state.isManager !== nextProps.isManager;
     const isEmployeeChange = this.state.isEmployee !== nextProps.isEmployee;
 
@@ -102,6 +106,7 @@ const UserDashboard = React.createClass({
       managerRequests: managerRequestsChange ?
         nextProps.managerRequests : this.state.managerRequests,
       users: usersChange ? nextProps.users : this.state.users,
+      projectNames: projectNamesChange ? nextProps.projectNames : this.state.projectNames,
       isManager: isManagerChange ? nextProps.isManager : this.state.isManager,
       isEmployee: isEmployeeChange ? nextProps.isEmployee : this.state.isEmployee,
       viewToggle: this.state.viewToggle && this.props.isManager,
@@ -175,13 +180,13 @@ const UserDashboard = React.createClass({
   },
 
   createRequestCard(item) {
-    Meteor.call('projects.name', item.projectId, (err, results) => {
-      if (err) {
-        console.log(err);
-      } else {
-        this.projectName = results;
+    let projectName = '';
+    for (let i = 0; i < this.state.projectNames.length; i += 1) {
+      const nextProject = this.state.projectNames[i];
+      if (nextProject._id === item.projectId) {
+        projectName = nextProject.name;
       }
-    });
+    }
 
     let status = '';
     if (item.status === undefined || item.status === null) {
@@ -196,7 +201,7 @@ const UserDashboard = React.createClass({
       <Col xs={12} sm={12} md={6} lg={4} style={{ paddingTop: '10px', paddingBottom: '10px' }}>
         <Card>
           <CardHeader
-            title={this.projectName}
+            title={projectName}
             subtitle={`Submitted on ${dateFormat(item.bornOn, 'mmmm d, yyyy')}`}
             actAsExpander
             showExpandableButton


### PR DESCRIPTION
The bug occurred because we were setting a state variable for each card, which would overwrite with each new card. Now all necessary project names are loaded in the container.

Closes issue #102 